### PR TITLE
feat: 회원가입 페이지 도로명 주소 api 연동 및 Vite 개발 서버 프록시 설정

### DIFF
--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -1,0 +1,85 @@
+import axios from 'axios';
+
+// API 기본 URL 설정 (프록시 사용)
+const API_URL = '/api/auth';
+
+export const authService = {
+  // 회원가입
+  signup: async (userData) => {
+    try {
+      const response = await axios.post(API_URL + '/signup', userData, {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
+      return response.data;
+    } catch (error) {
+      console.error('회원가입 오류:', error);
+      throw error.response?.data || { message: '회원가입 중 오류가 발생했습니다.' };
+    }
+  },
+  
+  // 로그인
+  login: async (credentials) => {
+    try {
+      const response = await axios.post(API_URL + '/login', credentials, {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
+      if (response.data.accessToken) {
+        localStorage.setItem('user', JSON.stringify(response.data));
+      }
+      return response.data;
+    } catch (error) {
+      console.error('로그인 오류:', error);
+      throw error.response?.data || { message: '로그인 중 오류가 발생했습니다.' };
+    }
+  },
+  
+  // 로그아웃
+  logout: () => {
+    localStorage.removeItem('user');
+  },
+  
+  // 토큰 재발급
+  refreshToken: async (refreshToken) => {
+    try {
+      const response = await axios.post(API_URL + '/refresh', { refreshToken });
+      if (response.data.accessToken) {
+        localStorage.setItem('user', JSON.stringify(response.data));
+      }
+      return response.data;
+    } catch (error) {
+      console.error('토큰 재발급 오류:', error);
+      throw error.response?.data || { message: '토큰 재발급 중 오류가 발생했습니다.' };
+    }
+  },
+  
+  // 현재 사용자 정보 가져오기
+  getCurrentUser: () => {
+    return JSON.parse(localStorage.getItem('user'));
+  },
+  
+  // 이메일 인증 요청
+  requestEmailVerification: async (email) => {
+    try {
+      const response = await axios.post(API_URL + '/email/verification-request', { email });
+      return response.data;
+    } catch (error) {
+      console.error('이메일 인증 요청 오류:', error);
+      throw error.response?.data || { message: '이메일 인증 요청 중 오류가 발생했습니다.' };
+    }
+  },
+  
+  // 이메일 인증 확인
+  verifyEmail: async (email, code) => {
+    try {
+      const response = await axios.post(API_URL + '/email/verify', { email, code });
+      return response.data;
+    } catch (error) {
+      console.error('이메일 인증 확인 오류:', error);
+      throw error.response?.data || { message: '이메일 인증 확인 중 오류가 발생했습니다.' };
+    }
+  }
+};

--- a/src/pages/Login/LoginPage.jsx
+++ b/src/pages/Login/LoginPage.jsx
@@ -127,7 +127,20 @@ const LoginPage = () => {
       {/* 상단 바 */}
       <AppBar position="static" elevation={0} sx={{ backgroundColor: 'white', color: 'black', py: 1 }}>
         <Toolbar>
-          <img src={logoSmall} alt="밀포유" style={{ height: 32 }} />
+          <button 
+            onClick={() => navigate('/')} 
+            style={{ 
+              background: 'none', 
+              border: 'none', 
+              padding: 0, 
+              cursor: 'pointer',
+              display: 'flex',
+              alignItems: 'center',
+              height: '32px'
+            }}
+          >
+            <img src={logoSmall} alt="밀포유" style={{ height: '100%' }} />
+          </button>
         </Toolbar>
       </AppBar>
 

--- a/src/pages/Signup/SignupPage.jsx
+++ b/src/pages/Signup/SignupPage.jsx
@@ -1,12 +1,28 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { styled } from '@mui/material/styles';
+import { authService } from '../../api/auth';
 import logoSmall from '../../assets/images/logo_small.png';
 import eyeIcon from '../../assets/eye.svg';
 import eyeHideIcon from '../../assets/eye-hide-line.svg';
 import lockIcon from '../../assets/lock.svg';
 import correctIcon from '../../assets/correct.svg';
 import wrongIcon from '../../assets/wrong.svg';
+
+// Daum Postcode Script
+const loadDaumPostcodeScript = () => {
+  return new Promise((resolve) => {
+    if (window.daum && window.daum.Postcode) {
+      return resolve();
+    }
+    const script = document.createElement('script');
+    script.src = '//t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js';
+    script.onload = () => resolve();
+    script.onerror = () => console.error('Failed to load Daum Postcode script');
+    document.head.appendChild(script);
+  });
+};
+
 
 const SignupContainer = styled('div')({
   width: '100%',
@@ -50,7 +66,6 @@ const Header = styled('header')({
     height: '32px',
   },
 });
-
 
 const Title = styled('h2')({
   fontSize: '20px',
@@ -150,6 +165,20 @@ const SubmitButton = styled('button')(({ theme }) => ({
 }));
 
 export default function SignupPage() {
+  // 컴포넌트 마운트 시 Daum Postcode 스크립트 로드
+  useEffect(() => {
+    loadDaumPostcodeScript().catch(error => {
+      console.error('Failed to load Daum Postcode script:', error);
+    });
+    
+    // 컴포넌트 언마운트 시 정리
+    return () => {
+      // Daum Postcode 팝업이 열려있을 경우 닫기
+      if (window.daum && window.daum.Postcode && window.daum.Postcode.close) {
+        window.daum.Postcode.close();
+      }
+    };
+  }, []);
   const navigate = useNavigate();
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
@@ -168,6 +197,13 @@ export default function SignupPage() {
     phone2: '',
     phone3: '',
     email: ''
+  });
+
+  const [address, setAddress] = useState({
+    postcode: '',
+    roadAddress: '',
+    detailAddress: '',
+    extraAddress: ''
   });
 
   const timerRef = useRef();
@@ -212,6 +248,56 @@ export default function SignupPage() {
     setPasswordError(checkPasswordMatch(password, newConfirmPassword));
   };
 
+  // 주소 검색 핸들러
+  const handleAddressSearch = () => {
+    loadDaumPostcodeScript().then(() => {
+      new window.daum.Postcode({
+        oncomplete: function(data) {
+          let fullAddress = data.address;
+          let extraAddress = '';
+          
+          if (data.addressType === 'R') {
+            if (data.bname !== '') {
+              extraAddress += data.bname;
+            }
+            if (data.buildingName !== '') {
+              extraAddress += extraAddress !== '' ? `, ${data.buildingName}` : data.buildingName;
+            }
+            fullAddress += extraAddress !== '' ? ` (${extraAddress})` : '';
+          }
+
+          setAddress(prev => ({
+            ...prev,
+            postcode: data.zonecode,
+            roadAddress: fullAddress,
+            extraAddress: extraAddress
+          }));
+          
+          // 상세주소 입력 필드로 포커스 이동
+          document.getElementById('detailAddress')?.focus();
+        },
+        width: '100%',
+        height: '100%',
+        maxSuggestItems: 7
+      }).open({
+        left: (window.screen.width / 2) - 200,
+        top: (window.screen.height / 2) - 300
+      });
+    }).catch(error => {
+      console.error('Failed to load address search:', error);
+      alert('주소 검색을 불러오는 데 실패했습니다. 새로고침 후 다시 시도해주세요.');
+    });
+  };
+
+  // 주소 입력 변경 핸들러
+  const handleAddressChange = (e) => {
+    const { name, value } = e.target;
+    setAddress(prev => ({
+      ...prev,
+      [name]: value
+    }));
+  };
+
   // 인증 코드 전송 처리
   const handleSendVerification = () => {
     setVerificationSent(true);
@@ -231,7 +317,10 @@ export default function SignupPage() {
       verificationCode &&
       password && 
       confirmPassword &&
-      !passwordError;
+      !passwordError &&
+      address.postcode &&
+      address.roadAddress &&
+      address.detailAddress;
     
     setIsFormValid(!!isAllFieldsFilled);
   }, [formData, verificationCode, password, confirmPassword, passwordError]);
@@ -321,15 +410,53 @@ export default function SignupPage() {
       <FormGroup>
         <label>주소</label>
         <InputGroup>
-          <input type="text" placeholder="우편번호" />
-          <button style={{ color: '#FFFFFF' }}>우편번호 찾기</button>
+          <input 
+            type="text" 
+            placeholder="우편번호" 
+            value={address.postcode}
+            readOnly
+            style={{ backgroundColor: '#FFFFFF' }}
+          />
+          <button 
+            type="button"
+            onClick={handleAddressSearch}
+            style={{ 
+              backgroundColor: '#CDD1D5',
+              color: '#FFFFFF',
+              whiteSpace: 'nowrap',
+              flexShrink: 0,
+              padding: '0 16px',
+              borderRadius: '24px'
+            }}
+          >
+            우편번호 찾기
+          </button>
         </InputGroup>
         <InputGroup>
-          <input type="text" placeholder="주소" />
+          <input 
+            type="text" 
+            placeholder="도로명주소" 
+            value={address.roadAddress}
+            readOnly
+            style={{ backgroundColor: '#FFFFFF' }}
+          />
         </InputGroup>
         <InputGroup>
-          <input type="text" placeholder="상세주소" />
-          <input type="text" placeholder="참고항목" />
+          <input 
+            type="text" 
+            id="detailAddress"
+            name="detailAddress"
+            placeholder="상세주소" 
+            value={address.detailAddress}
+            onChange={handleAddressChange}
+          />
+          <input 
+            type="text" 
+            placeholder="참고항목" 
+            value={address.extraAddress}
+            readOnly
+            style={{ backgroundColor: '#FFFFFF' }}
+          />
         </InputGroup>
       </FormGroup>
 

--- a/src/pages/Signup/SignupPage.jsx
+++ b/src/pages/Signup/SignupPage.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { styled } from '@mui/material/styles';
 import { authService } from '../../api/auth';
-import logoSmall from '../../assets/images/logo_small.png';
+import logoSmall from '../../assets/mealforyou_logo.svg';
 import eyeIcon from '../../assets/eye.svg';
 import eyeHideIcon from '../../assets/eye-hide-line.svg';
 import lockIcon from '../../assets/lock.svg';
@@ -349,7 +349,12 @@ export default function SignupPage() {
   return (
     <SignupContainer>
       <Header>
-        <img src={logoSmall} alt="밀포유" />
+        <button 
+          onClick={() => navigate('/')} 
+          style={{ background: 'none', border: 'none', padding: 0, cursor: 'pointer' }}
+        >
+          <img src={logoSmall} alt="밀포유" />
+        </button>
       </Header>
 
       <Title>회원가입</Title>

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,4 +4,13 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8080',
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api/, ''),
+      }
+    }
+  }
 })


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #이슈번호

## 📌 회원가입 페이지 도로명 주소 api 연동 및 Vite 개발 서버 프록시 설정 
<!-- 간단하게 기능/버그 수정 요약  -->

## 📝 작업 내용
- Vite 개발 서버 프록시 설정 추가
외부 API 연동을 위해 Vite 개발 서버에 '/api' 프록시 설정을 추가함.
'/api' 경로 요청을 'http://localhost:8080'으로 포워딩하도록 설정.
- 회원가입 페이지 도로명 주소 api 연동
다음카카오 도로명 주소 api 연결
- 
<img width="1030" height="1200" alt="image" src="https://github.com/user-attachments/assets/6e04b18d-b882-4643-b8fe-937b5e4867a0" />

## ✅ 체크리스트
- [ ] 이 기능/수정이 정상적으로 동작하나요?
- [ ] 배포 전 모든 테스트 통과했나요?
- [ ] 최신 main 브랜치와 충돌 없이 병합 가능한가요?
- [ ] 브랜치 잘 지정했나요?
- [ ] 관련 문서나 주석을 최신 상태로 업데이트했나요?

## 🗣️ 팀원에게 공유할 내용
<!-- 팀원들이 알아야 할 내용이나 논의해야 할 부분이 있다면 작성 -->
`npm install axios
`
axois 설치