### PR TITLE
refactor: 배포 도중 import 경로의 대소문자 차이로 발생한 이슈 해결

### DIFF
--- a/src/pages/Productdetail/pd.jsx
+++ b/src/pages/Productdetail/pd.jsx
@@ -4,13 +4,13 @@ import { Pagination, Mousewheel } from "swiper/modules";
 import { useNavigate } from "react-router-dom";
 import StatusBar from "../../components/StatusBar";
 import Header from "../../components/Header";
-import BottomSheet from "./bottomsheet";
+import BottomSheet from "./BottomSheet";
 import CartModal from "./CartModal";
 
 import "swiper/css";
 import "swiper/css/pagination";
 
-import "./Pd.css";
+import "./pd.css";
 import bibimbap from "../../assets/images/bibimbap.png";
 import bibimbap2 from "../../assets/images/bibimbap2.png";
 import heart from "../../assets/images/heart-m.png";


### PR DESCRIPTION
src/pages/Productdetail/pd.jsx 파일에서 에러 발생.

import BottomSheet from "./bottomsheet";
import "./Pd.css";
를 실제 파일명에 맞추어
import BottomSheet from "./BottomSheet";
import "./pd.css";
로 수정함.